### PR TITLE
Add: Profiling Interface

### DIFF
--- a/coalib/bearlib/__init__.py
+++ b/coalib/bearlib/__init__.py
@@ -5,12 +5,21 @@ while offering the best possible flexibility.
 """
 
 import logging
-from functools import wraps
 
 from coalib.settings.FunctionMetadata import FunctionMetadata
 
 
 def _do_nothing(x): return x
+
+
+def profile_bears_decorator(func):
+    def wrapper_function(*args, **kwargs):
+        prof = kwargs.get('profiler', False)
+        kwargs.pop('profiler')
+        if prof:
+            prof.enable()
+        return func(*args, **kwargs)
+    return wrapper_function
 
 
 def deprecate_settings(**depr_args):
@@ -99,7 +108,6 @@ def deprecate_settings(**depr_args):
 
         logged_deprecated_args = set()
 
-        @wraps(func)
         def wrapping_function(*args, **kwargs):
             for arg, depr_value in wrapping_function.__metadata__.depr_values:
                 deprecated_arg = depr_value[0]
@@ -119,7 +127,12 @@ def deprecate_settings(**depr_args):
                     else:
                         kwargs[arg] = depr_arg_value
                     del kwargs[deprecated_arg]
-            return func(*args, **kwargs)
+            profile_bears = kwargs.get('profile_bears', False)
+            str_profile_bears = str(profile_bears).lower().strip()
+            if not str_profile_bears == u'false':
+                kwargs.pop('profile_bears')
+            return profile_bears_decorator(func)(*args, **kwargs) if not (
+                str_profile_bears == u'false') else func(*args, **kwargs)
 
         new_metadata = FunctionMetadata.from_function(func)
         new_metadata.depr_values = []

--- a/coalib/bearlib/aspects/decorators.py
+++ b/coalib/bearlib/aspects/decorators.py
@@ -6,6 +6,16 @@ from .meta import aspectclass
 from coalib.settings.FunctionMetadata import FunctionMetadata
 
 
+def profile_bears_decorator(func):
+    def wrapper_function(self,*args, **kwargs):
+        prof = kwargs.get('profiler', False)
+        kwargs.pop('profiler')
+        if prof:
+            prof.enable()
+        return func(self,*args, **kwargs)
+    return wrapper_function
+
+
 def map_setting_to_aspect(**aspectable_setting):
     """
     Map function arguments with aspect and override it if appropriate.
@@ -24,7 +34,6 @@ def map_setting_to_aspect(**aspectable_setting):
         as value.
     """
     def _func_decorator(func):
-        @wraps(func)
         def _new_func(self, *args, **kwargs):
             if self.section.aspects:
                 aspects = self.section.aspects
@@ -41,7 +50,14 @@ def map_setting_to_aspect(**aspectable_setting):
                             kwargs[arg] = aspect_instance.tastes[
                                 aspect_value.name]
 
-            return func(self, *args, **kwargs)
+            # return func(self, *args, **kwargs)
+            profile_bears = kwargs.get('profile_bears', False)
+            str_profile_bears = str(profile_bears).lower().strip()
+            if not str_profile_bears == u'false':
+                kwargs.pop('profile_bears')
+            return profile_bears_decorator(func)(self,*args, **kwargs) if not (
+                str_profile_bears == u'false') else func(self,*args, **kwargs)
+
 
         # Keep metadata
         _new_func.__metadata__ = FunctionMetadata.from_function(func)

--- a/coalib/parsing/DefaultArgParser.py
+++ b/coalib/parsing/DefaultArgParser.py
@@ -241,6 +241,13 @@ To run coala without user interaction, run the `coala --non-interactive`,
         '-r', '--relpath', nargs='?', const=True,
         help='return relative paths for files (must be called with --json)')
 
+    outputs_group.add_argument(
+        '--profile-bears', nargs='?', const=True,
+        default=False,  help='Provide profiler stats for `--profile-bears`'
+                             'as a file to the given directory or dump to'
+                             'console if none provided for all the bears'
+                             'being run')
+
     misc_group = arg_parser.add_argument_group('Miscellaneous')
 
     misc_group.add_argument(

--- a/coalib/processes/BearRunning.py
+++ b/coalib/processes/BearRunning.py
@@ -100,7 +100,7 @@ def run_bear(message_queue, timeout, bear_instance, *args, debug=False,
         del kwargs['dependency_results']
 
     name = bear_instance.name
-
+    kwargs['bear_name'] = name
     try:
         result_list = bear_instance.execute(*args, debug=debug, **kwargs)
     except (Exception, SystemExit) as exc:
@@ -167,7 +167,9 @@ def run_local_bear(message_queue,
                    file_dict,
                    bear_instance,
                    filename,
-                   debug=False):
+                   section_name,
+                   debug=False,
+                   profile_bears=False):
     """
     Runs an instance of a local bear. Checks if bear_instance is of type
     LocalBear and then passes it to the run_bear to execute.
@@ -200,7 +202,9 @@ def run_local_bear(message_queue,
     kwargs = {'dependency_results':
               get_local_dependency_results(local_result_list,
                                            bear_instance),
-              'debug': debug}
+              'debug': debug,
+              'profile_bears': profile_bears,
+              'section_name': section_name}
     return run_bear(message_queue,
                     timeout,
                     bear_instance,
@@ -213,7 +217,9 @@ def run_global_bear(message_queue,
                     timeout,
                     global_bear_instance,
                     dependency_results,
-                    debug=False):
+                    section_name,
+                    debug=False,
+                    profile_bears=False):
     """
     Runs an instance of a global bear. Checks if bear_instance is of type
     GlobalBear and then passes it to the run_bear to execute.
@@ -245,7 +251,9 @@ def run_global_bear(message_queue,
         return None
 
     kwargs = {'dependency_results': dependency_results,
-              'debug': debug}
+              'debug': debug,
+              'profile_bears': profile_bears,
+              'section_name': section_name}
     return run_bear(message_queue,
                     timeout,
                     global_bear_instance,
@@ -259,7 +267,9 @@ def run_local_bears_on_file(message_queue,
                             local_result_dict,
                             control_queue,
                             filename,
-                            debug=False):
+                            section_name,
+                            debug=False,
+                            profile_bears=False):
     """
     This method runs a list of local bears on one file.
 
@@ -303,7 +313,9 @@ def run_local_bears_on_file(message_queue,
                                 file_dict,
                                 bear_instance,
                                 filename,
-                                debug=debug)
+                                section_name,
+                                debug=debug,
+                                profile_bears=profile_bears)
         if result is not None:
             local_result_list.extend(result)
 
@@ -393,7 +405,9 @@ def run_local_bears(filename_queue,
                     local_bear_list,
                     local_result_dict,
                     control_queue,
-                    debug=False):
+                    section_name,
+                    debug=False,
+                    profile_bears=False):
     """
     Run local bears on all the files given.
 
@@ -426,7 +440,9 @@ def run_local_bears(filename_queue,
                                     local_result_dict,
                                     control_queue,
                                     filename,
-                                    debug=debug)
+                                    section_name,
+                                    debug=debug,
+                                    profile_bears=profile_bears)
             task_done(filename_queue)
     except queue.Empty:
         return
@@ -438,7 +454,9 @@ def run_global_bears(message_queue,
                      global_bear_list,
                      global_result_dict,
                      control_queue,
-                     debug=False):
+                     section_name,
+                     debug=False,
+                     profile_bears=False):
     """
     Run all global bears.
 
@@ -468,8 +486,9 @@ def run_global_bears(message_queue,
                                      global_bear_list,
                                      global_result_dict))
             bearname = bear.__class__.__name__
-            result = run_global_bear(message_queue, timeout, bear, dep_results,
-                                     debug=debug)
+            result = run_global_bear(message_queue, timeout, bear, section_name,
+                                     dep_results, debug=debug,
+                                     profile_bears=profile_bears)
             if result:
                 global_result_dict[bearname] = result
                 control_queue.put((CONTROL_ELEMENT.GLOBAL, bearname))
@@ -489,8 +508,10 @@ def run(file_name_queue,
         global_result_dict,
         message_queue,
         control_queue,
+        section_name,
         timeout=0,
-        debug=False):
+        debug=False,
+        profile_bears=False):
     """
     This is the method that is actually runs by processes.
 
@@ -548,7 +569,9 @@ def run(file_name_queue,
                         local_bear_list,
                         local_result_dict,
                         control_queue,
-                        debug=debug)
+                        section_name,
+                        debug=debug,
+                        profile_bears=profile_bears)
         control_queue.put((CONTROL_ELEMENT.LOCAL_FINISHED, None))
 
         run_global_bears(message_queue,
@@ -557,7 +580,9 @@ def run(file_name_queue,
                          global_bear_list,
                          global_result_dict,
                          control_queue,
-                         debug=debug)
+                         section_name,
+                         debug=debug,
+                         profile_bears=profile_bears)
         control_queue.put((CONTROL_ELEMENT.GLOBAL_FINISHED, None))
     except (OSError, KeyboardInterrupt):  # pragma: no cover
         if debug:

--- a/coalib/processes/Processing.py
+++ b/coalib/processes/Processing.py
@@ -450,7 +450,9 @@ def instantiate_processes(section,
                         'message_queue': message_queue,
                         'control_queue': control_queue,
                         'timeout': 0.1,
-                        'debug': debug}
+                        'debug': debug,
+                        'profile_bears': section['profile_bears'],
+                        'section_name': section.name}
 
     fill_queue(filename_queue, file_dict.keys())
     fill_queue(global_bear_queue, range(len(global_bear_list)))


### PR DESCRIPTION
Add the profile interface with all the detail:
Lets take a 

1. Dump the profile result of every bear of every section, (using `CLI` and `.coafile`) 
it will be something like {section_name}{bear_name}.prof so that if user want to make a sunburn diagram of any bear of any section they can easily do that.
```
[python ]
bears = SpaceConsistencyBear,PyUnusedCodeBear,PEP8Bear
files = mytest.py
use_spaces = False
profile_bears=True,dump
```
Asciinema url - https://asciinema.org/a/VCsAxd93YBd77HqG3LiypzO7E

2. Passing the profiler ouput to `pstats` module and display it on terminal  with all the settings like `strip_dirs(),sort_stats('cumtime')`  (using `CLI` and `.coafile`) 
```
[python ]
bears = SpaceConsistencyBear,PyUnusedCodeBear,PEP8Bear
files = mytest.py
use_spaces = False
profile_bears=True,strip_dirs(),sort_stats('ncalls'),no_trim
```
Asciinema Url - https://asciinema.org/a/P4jvMPSo60rOw8PFaaDd6V8ag

3. Passing the profiler ouput to `pstats` module and with all the settings like `strip_dirs(),sort_stats('cumtime')`  (using `CLI` and `.coafile`)  and dump it to the specified file.

Asciinema url - https://asciinema.org/a/tXPOXs3b1ef8aA5LAcShFFSPk

Related to https://github.com/coala/coala/issues/565