### PR TITLE
Bears.py: Add Debugger Setting toolset

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ python_files = *Test.py
 python_classes = *Test
 timeout = 35
 addopts =
+    -s
     -p no:logging
     --instafail
     --reorder 'requirements.txt' 'test-requirements.txt' '*'

--- a/tests/bears/BearTest.py
+++ b/tests/bears/BearTest.py
@@ -124,6 +124,15 @@ class StandAloneBear(Bear):
         yield z
 
 
+class TestTwoBear(LocalBear):
+    def __init__(self, section, queue, timeout=0.1, debugger=False):
+        Bear.__init__(self, section, queue, timeout, debugger)
+
+    def run(self, filename, file, x: int, y: str, z: int = 79, w: str = 'kbc'):
+        yield 1
+        yield 2
+
+
 class DependentBear(Bear):
 
     BEAR_DEPS = {StandAloneBear}
@@ -488,6 +497,25 @@ class BearTest(BearTestBase):
         args = ()
         kwargs = {}
         self.assertIsNone(my_bear.run_bear_from_section(args, kwargs))
+
+    def test_debugger_settings_with_self_onscope(self):
+        section = Section('name', None)
+        section.append(Setting('x', '85'))
+        section.append(Setting('y', 'kbc3'))
+        my_bear = TestTwoBear(section, self.queue)
+        Debugger.curframe_locals = {'x': 2, 'y': 'kbc2', 'some': {'z': 79},
+                                    'self': my_bear}
+        arg = 'z = 3;abc= 78; z=kbc'
+        dbg = Debugger()
+        dbg.do_settings(arg)
+        self.assertEqual(dbg.setting_dict, {'z': 3})
+        arg = ''
+        dbg.do_settings(arg)
+
+    def test_debugger_settings_no_self_inscope(self):
+        arg = ' '
+        Debugger.curframe_locals = {'x': 2, 'z': 79, 'w': 'kbc'}
+        Debugger().do_settings(arg)
 
 
 class BrokenReadHTTPResponse(BytesIO):

--- a/tests/bears/DebugBearsTest.py
+++ b/tests/bears/DebugBearsTest.py
@@ -1,9 +1,22 @@
+import multiprocessing
 import unittest
 import sys
 
 from io import StringIO
 
-from coalib.bears.Bear import Debugger, debug_run
+from coalib.bears.Bear import Bear, Debugger, debug_run
+from coalib.bears.LocalBear import LocalBear
+from coalib.settings.Section import Section
+from coalib.settings.Setting import Setting
+
+
+class TestOneBear(LocalBear):
+    def __init__(self, section, queue, timeout=0.1, debugger=False):
+        Bear.__init__(self, section, queue, timeout, debugger)
+
+    def run(self, filename, file, x: int, y: str, z: int = 79, w: str = 'kbc'):
+        yield 1
+        yield 2
 
 
 def func1(*args, **kwargs):
@@ -35,6 +48,8 @@ class DebugBearsTest(unittest.TestCase):
         # BearTest file.
         # https://goo.gl/sKaJfh
         self.trace = sys.gettrace()
+        self.queue = multiprocessing.Queue()
+        self.section = Section('name')
 
     def tearDown(self):
         sys.settrace(self.trace)
@@ -60,3 +75,28 @@ class DebugBearsTest(unittest.TestCase):
         self.assertEqual(lines[3], '-> yield 1')
         self.assertEqual(lines[5], '-> yield 2')
         self.assertEqual(lines[7], '-> yield 3')
+
+    def test_do_settings(self):
+        self.section.append(Setting('x', '85'))
+        self.section.append(Setting('y', 'kbc3'))
+        self.section.append(Setting('z', 86))
+        my_bear = TestOneBear(self.section, self.queue)
+        args = ('a', ('b', 'c'))
+        kwargs = {'x': 2, 'y': 'abc'}
+        result, output = execute_debugger(["settings x=3; y= 'abc2'; z=abc;"
+                                           'some_key=2', 'q', 'settings', 'c',
+                                           'q'], my_bear.run, *args, **kwargs)
+        # lines = output.splitlines()
+        print(output)
+        # self.assertEqual(lines[2], "(Pdb) name 'abc' is not defined")
+        # self.assertEqual(lines[3], "'some_key' key is not in scope")
+        # self.assertEqual(lines[6], '(Pdb) x = ')
+        # self.assertEqual(lines[7], "y = 'abc2'")
+        # self.assertEqual(lines[8], 'z = 86')
+        # self.assertEqual(lines[9], "w = 'kbc'")
+        # self.assertEqual(lines, 1)
+
+    def test_do_settings_without_selfOfBear(self):
+        result, output = execute_debugger(['settings'], func1)
+        lines = output.splitlines()
+        self.assertEqual(lines[2], '(Pdb) self is not in scope')


### PR DESCRIPTION
Add the code of Settings inspection toolset so that user can access the settings of a Bear in Debug environment and add an initial test.